### PR TITLE
Add Data Product functionality via templates

### DIFF
--- a/.github/workflows/dataLandingZone.yml
+++ b/.github/workflows/dataLandingZone.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/_terraformApplyTemplate.yml
     name: "Terraform Apply"
     needs: [terraform_plan_dev]
-    # if: github.event_name == 'push' || github.event_name == 'release'
+    if: github.event_name == 'push' || github.event_name == 'release'
     with:
       environment: "dev"
       terraform_version: "1.4.2"

--- a/.github/workflows/dataLandingZone.yml
+++ b/.github/workflows/dataLandingZone.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/_terraformApplyTemplate.yml
     name: "Terraform Apply"
     needs: [terraform_plan_dev]
-    if: github.event_name == 'push' || github.event_name == 'release'
+    # if: github.event_name == 'push' || github.event_name == 'release'
     with:
       environment: "dev"
       terraform_version: "1.4.2"

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+.terraform.lock.hcl

--- a/code/data-landing-zone/dataproducts.tf
+++ b/code/data-landing-zone/dataproducts.tf
@@ -1,30 +1,38 @@
 module "data_products" {
-  source = "./modules/dataproduct"
-  for_each = {
-    for item in local.data_product_definitions_per_env : "dp-${item.id}-${item.env}" => item.properties
+  source   = "./modules/dataproduct"
+  for_each = local.data_product_definitions
+  providers = {
+    databricks = each.value.databricks.experimentation ? databricks.experimentation : databricks.automation
   }
 
   location                       = var.location
-  data_product_name              = each.key
-  tags                           = each.value.tags
-  network_enabled                = each.value.network.enabled
+  data_product_name              = try("${each.value.id}-${each.value.environment}", "")
+  tags                           = try(each.value.tags, {})
+  network_enabled                = try(each.value.network.enabled, false)
   vnet_id                        = data.azurerm_virtual_network.virtual_network.id
   nsg_id                         = var.nsg_id
   route_table_id                 = var.route_table_id
-  subnet_cidr_range              = each.value.network.subnet_cidr_range
+  subnet_cidr_range              = try(each.value.network.subnet_cidr_range, "")
   private_dns_zone_id_key_vault  = var.private_dns_zone_id_key_vault
-  identity_enabled               = each.value.identity.enabled
-  security_group_display_name    = each.value.identity.security_group_display_name
-  user_assigned_identity_enabled = each.value.identity.user_assigned_identity_enabled
-  service_principal_enabled      = each.value.identity.service_principal_enabled
+  identity_enabled               = try(each.value.identity.enabled, false)
+  security_group_display_name    = try(each.value.identity.security_group_display_name, "")
+  user_assigned_identity_enabled = try(each.value.identity.user_assigned_identity_enabled, false)
+  service_principal_enabled      = try(each.value.identity.service_principal_enabled, false)
   containers_enabled = {
-    raw       = each.value.storage_container.raw
-    enriched  = each.value.storage_container.enriched
-    curated   = each.value.storage_container.curated
-    workspace = each.value.storage_container.workspace
+    raw       = try(each.value.storage_container.raw, false)
+    enriched  = try(each.value.storage_container.enriched, false)
+    curated   = try(each.value.storage_container.curated, false)
+    workspace = try(each.value.storage_container.workspace, false)
   }
   datalake_raw_id       = module.datalake_raw.datalake_id
   datalake_enriched_id  = module.datalake_enriched.datalake_id
   datalake_curated_id   = module.datalake_curated.datalake_id
   datalake_workspace_id = module.datalake_workspace.datalake_id
+  databricks_enabled    = try(each.value.databricks.enabled, false)
+  unity_metastore_id    = var.unity_metastore_id
+  unity_catalog_configurations = {
+    enabled      = try(each.value.databricks.unity_catalog.enabled, false)
+    group_name   = try(each.value.databricks.unity_catalog.group_name, "")
+    storage_root = try(each.value.databricks.unity_catalog.storage_root, "")
+  }
 }

--- a/code/data-landing-zone/dataproducts.tf
+++ b/code/data-landing-zone/dataproducts.tf
@@ -12,6 +12,7 @@ module "data_products" {
   nsg_id                         = var.nsg_id
   route_table_id                 = var.route_table_id
   subnet_cidr_range              = each.value.network.subnet_cidr_range
+  private_dns_zone_id_key_vault  = var.private_dns_zone_id_key_vault
   identity_enabled               = each.value.identity.enabled
   security_group_display_name    = each.value.identity.security_group_display_name
   user_assigned_identity_enabled = each.value.identity.user_assigned_identity_enabled

--- a/code/data-landing-zone/dataproducts.tf
+++ b/code/data-landing-zone/dataproducts.tf
@@ -2,7 +2,8 @@ module "data_products" {
   source   = "./modules/dataproduct"
   for_each = local.data_product_definitions
   providers = {
-    databricks = each.value.databricks.experimentation ? databricks.experimentation : databricks.automation
+    databricks.automation      = databricks.automation
+    databricks.experimentation = databricks.experimentation
   }
 
   location                       = var.location
@@ -24,12 +25,13 @@ module "data_products" {
     curated   = try(each.value.storage_container.curated, false)
     workspace = try(each.value.storage_container.workspace, false)
   }
-  datalake_raw_id       = module.datalake_raw.datalake_id
-  datalake_enriched_id  = module.datalake_enriched.datalake_id
-  datalake_curated_id   = module.datalake_curated.datalake_id
-  datalake_workspace_id = module.datalake_workspace.datalake_id
-  databricks_enabled    = try(each.value.databricks.enabled, false)
-  unity_metastore_id    = var.unity_metastore_id
+  datalake_raw_id            = module.datalake_raw.datalake_id
+  datalake_enriched_id       = module.datalake_enriched.datalake_id
+  datalake_curated_id        = module.datalake_curated.datalake_id
+  datalake_workspace_id      = module.datalake_workspace.datalake_id
+  databricks_enabled         = try(each.value.databricks.enabled, false)
+  databricks_experimentation = try(each.value.databricks.experimentation, true)
+  unity_metastore_id         = var.unity_metastore_id
   unity_catalog_configurations = {
     enabled      = try(each.value.databricks.unity_catalog.enabled, false)
     group_name   = try(each.value.databricks.unity_catalog.group_name, "")

--- a/code/data-landing-zone/dataproducts.tf
+++ b/code/data-landing-zone/dataproducts.tf
@@ -2,8 +2,9 @@ module "data_products" {
   source   = "./modules/dataproduct"
   for_each = local.data_product_definitions
   providers = {
-    databricks.automation      = databricks.automation
+    databricks                 = databricks.experimentation
     databricks.experimentation = databricks.experimentation
+    databricks.automation      = databricks.automation
   }
 
   location                       = var.location

--- a/code/data-landing-zone/dataproducts.tf
+++ b/code/data-landing-zone/dataproducts.tf
@@ -13,8 +13,8 @@ module "data_products" {
   route_table_id                 = var.route_table_id
   subnet_cidr_range              = each.value.network.subnet_cidr_range
   identity_enabled               = each.value.identity.enabled
-  security_group_display_name    = each.value.identity.enabled
-  user_assigned_identity_enabled = each.value.identity.security_group_display_name
+  security_group_display_name    = each.value.identity.security_group_display_name
+  user_assigned_identity_enabled = each.value.identity.user_assigned_identity_enabled
   service_principal_enabled      = each.value.identity.service_principal_enabled
   containers_enabled = {
     raw       = each.value.storage_container.raw

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -1,8 +1,7 @@
 id: "test"
+environment: "prd"
 tags:
   costCenter: "ABCD1234"
-environments:
-  - "dev"
 network:
   enabled: true
   subnet_cidr_range: "100.0.32.96/28"
@@ -12,15 +11,14 @@ identity:
   user_assigned_identity_enabled: true
   service_principal_enabled: true
 storage_container:
-  raw: true
-  enriched: true
-  curated: true
-  workspace: false
+  raw: false
+  enriched: false
+  curated: false
+  workspace: true
 databricks:
   enabled: true
-  automation: true
   experimentation: false
-  cluster:
-    sku: ""
-  catalog:
-    name: ""
+  unity_catalog:
+    enabled: true
+    group_name: "test"
+    storage_root: "workspace"

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -20,5 +20,5 @@ databricks:
   experimentation: false
   unity_catalog:
     enabled: true
-    group_name: "test"
+    group_name: "377231223141289"
     storage_root: "workspace"

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -8,7 +8,7 @@ network:
   subnet_cidr_range: "100.0.32.96/28"
 identity:
   enabled: true
-  security_group_display_name: ""
+  security_group_display_name: "test"
   user_assigned_identity_enabled: true
   service_principal_enabled: false
 storage_container:

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -4,7 +4,7 @@ tags:
   costCenter: "ABCD1234"
 network:
   enabled: true
-  subnet_cidr_range: "100.0.32.96/28"
+  subnet_cidr_range: "10.0.32.96/28"
 identity:
   enabled: true
   security_group_display_name: "test"

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -8,7 +8,9 @@ network:
   subnet_cidr_range: "100.0.32.96/28"
 identity:
   enabled: true
-  security_group_name: ""
+  security_group_display_name: ""
+  user_assigned_identity_enabled: true
+  service_principal_enabled: false
 storage_container:
   raw: true
   enriched: true
@@ -22,6 +24,3 @@ databricks:
     sku: ""
   catalog:
     name: ""
-settings:
-  user_assigned_identity_enabled: true
-  service_principal_enabled: false

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -10,7 +10,7 @@ identity:
   enabled: true
   security_group_display_name: "test"
   user_assigned_identity_enabled: true
-  service_principal_enabled: false
+  service_principal_enabled: true
 storage_container:
   raw: true
   enriched: true

--- a/code/data-landing-zone/dataproducts/test.yml
+++ b/code/data-landing-zone/dataproducts/test.yml
@@ -20,5 +20,5 @@ databricks:
   experimentation: false
   unity_catalog:
     enabled: true
-    group_name: "377231223141289"
+    group_name: "test"
     storage_root: "workspace"

--- a/code/data-landing-zone/locals.tf
+++ b/code/data-landing-zone/locals.tf
@@ -28,15 +28,4 @@ locals {
     local.data_product_definitions_json,
     local.data_product_definitions_yaml
   )
-
-  # Create item per environment
-  data_product_definitions_per_env = flatten([
-    for definition_key, definition_value in local.data_product_definitions : [
-      for env in definition_value.environments : {
-        id         = definition_value.id
-        env        = env
-        properties = definition_value
-      }
-    ]
-  ])
 }

--- a/code/data-landing-zone/locals.tf
+++ b/code/data-landing-zone/locals.tf
@@ -16,11 +16,11 @@ locals {
   # Load file content
   data_product_definitions_json = {
     for filepath in local.data_product_filepaths_json :
-    filepath => jsondecode(templatefile("${local.data_product_library_path}/${filepath}", {}))
+    filepath => jsondecode(templatefile("${local.data_product_library_path}/${filepath}", var.data_product_template_file_variables))
   }
   data_product_definitions_yaml = {
     for filepath in local.data_product_filepaths_yaml :
-    filepath => yamldecode(templatefile("${local.data_product_library_path}/${filepath}", {}))
+    filepath => yamldecode(templatefile("${local.data_product_library_path}/${filepath}", var.data_product_template_file_variables))
   }
 
   # Merge data

--- a/code/data-landing-zone/main.tf
+++ b/code/data-landing-zone/main.tf
@@ -93,7 +93,7 @@ provider "databricks" {
   azure_workspace_resource_id = module.databricks_automation.databricks_id
   host                        = module.databricks_automation.databricks_workspace_url
   http_timeout_seconds        = 600
-  rate_limit                  = 10
+  # rate_limit                  = 10
 }
 
 provider "databricks" {
@@ -102,7 +102,7 @@ provider "databricks" {
   azure_workspace_resource_id = module.databricks_experimentation.databricks_id
   host                        = module.databricks_experimentation.databricks_workspace_url
   http_timeout_seconds        = 600
-  rate_limit                  = 10
+  # rate_limit                  = 10
 }
 
 data "azurerm_client_config" "current" {}

--- a/code/data-landing-zone/main.tf
+++ b/code/data-landing-zone/main.tf
@@ -18,6 +18,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.4.3"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.9.1"
+    }
     azuread = {
       source  = "hashicorp/azuread"
       version = "2.36.0"

--- a/code/data-landing-zone/main.tf
+++ b/code/data-landing-zone/main.tf
@@ -92,6 +92,8 @@ provider "databricks" {
   azure_environment           = "public"
   azure_workspace_resource_id = module.databricks_automation.databricks_id
   host                        = module.databricks_automation.databricks_workspace_url
+  http_timeout_seconds        = 600
+  rate_limit                  = 10
 }
 
 provider "databricks" {
@@ -99,6 +101,8 @@ provider "databricks" {
   azure_environment           = "public"
   azure_workspace_resource_id = module.databricks_experimentation.databricks_id
   host                        = module.databricks_experimentation.databricks_workspace_url
+  http_timeout_seconds        = 600
+  rate_limit                  = 10
 }
 
 data "azurerm_client_config" "current" {}

--- a/code/data-landing-zone/main.tf
+++ b/code/data-landing-zone/main.tf
@@ -93,7 +93,6 @@ provider "databricks" {
   azure_workspace_resource_id = module.databricks_automation.databricks_id
   host                        = module.databricks_automation.databricks_workspace_url
   http_timeout_seconds        = 600
-  # rate_limit                  = 10
 }
 
 provider "databricks" {
@@ -102,7 +101,6 @@ provider "databricks" {
   azure_workspace_resource_id = module.databricks_experimentation.databricks_id
   host                        = module.databricks_experimentation.databricks_workspace_url
   http_timeout_seconds        = 600
-  # rate_limit                  = 10
 }
 
 data "azurerm_client_config" "current" {}

--- a/code/data-landing-zone/modules/databricks/keyvault.tf
+++ b/code/data-landing-zone/modules/databricks/keyvault.tf
@@ -15,7 +15,7 @@ resource "azurerm_key_vault" "key_vault" {
     ip_rules                   = []
     virtual_network_subnet_ids = []
   }
-  public_network_access_enabled = true
+  public_network_access_enabled = false
   purge_protection_enabled      = true
   sku_name                      = "standard"
   soft_delete_retention_days    = 7

--- a/code/data-landing-zone/modules/databricksconfiguration/grants.tf
+++ b/code/data-landing-zone/modules/databricksconfiguration/grants.tf
@@ -1,9 +1,9 @@
-data "databricks_current_user" "current" {}
+data "databricks_current_user" "current_user" {}
 
-resource "databricks_grants" "sandbox" {
-  catalog = var.unity_metastore_id
+resource "databricks_grants" "grants_current_user" {
+  catalog = var.unity_metastore_name
   grant {
-    principal = data.databricks_current_user.current.user_name
+    principal = data.databricks_current_user.current_user.user_name
     privileges = [
       "CREATE_CATALOG",
       "CREATE_EXTERNAL_LOCATION"

--- a/code/data-landing-zone/modules/databricksconfiguration/grants.tf
+++ b/code/data-landing-zone/modules/databricksconfiguration/grants.tf
@@ -1,7 +1,7 @@
 data "databricks_current_user" "current_user" {}
 
 resource "databricks_grants" "grants_current_user" {
-  catalog = var.unity_metastore_name
+  metastore = var.unity_metastore_id
   grant {
     principal = data.databricks_current_user.current_user.user_name
     privileges = [

--- a/code/data-landing-zone/modules/databricksconfiguration/grants.tf
+++ b/code/data-landing-zone/modules/databricksconfiguration/grants.tf
@@ -1,0 +1,12 @@
+data "databricks_current_user" "current" {}
+
+resource "databricks_grants" "sandbox" {
+  catalog = var.unity_metastore_id
+  grant {
+    principal = data.databricks_current_user.current.user_name
+    privileges = [
+      "CREATE_CATALOG",
+      "CREATE_EXTERNAL_LOCATION"
+    ]
+  }
+}

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -5,7 +5,7 @@ data "azuread_group" "security_group" {
 }
 
 resource "azuread_group_member" "security_group_uai_member" {
-  count            = one(data.azuread_group.security_group[*].object_id) != null && one(azurerm_user_assigned_identity.user_assigned_identity[*].principal_id) != null ? 1 : 0
+  count            = var.user_assigned_identity_enabled && (data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
   member_object_id = one(azurerm_user_assigned_identity.user_assigned_identity[*].principal_id)
 }

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -36,7 +36,7 @@ resource "azuread_application" "application" {
 
 resource "azuread_service_principal" "service_principal" {
   count          = var.service_principal_enabled ? 1 : 0
-  application_id = one(azuread_application.application[*].id)
+  application_id = one(azuread_application.application[*].application_id)
   owners         = [data.azuread_client_config.current.object_id]
 
   account_enabled              = true

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -13,7 +13,7 @@ resource "azuread_group_member" "security_group_uai_member" {
 }
 
 resource "azuread_group_member" "security_group_dbac_member" {
-  count            = one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count            = var.databricks_enabled && var.unity_catalog_configurations.enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
   member_object_id = one(azurerm_databricks_access_connector.databricks_access_connector[*].identity[0].principal_id)
 }

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -1,3 +1,5 @@
+data "azuread_client_config" "current" {}
+
 data "azuread_group" "security_group" {
   count            = var.identity_enabled && var.security_group_display_name != "" ? 1 : 0
   display_name     = var.security_group_display_name

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -9,3 +9,56 @@ resource "azuread_group_member" "security_group_uai_member" {
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
   member_object_id = one(azurerm_user_assigned_identity.user_assigned_identity[*].principal_id)
 }
+
+resource "azuread_application" "application" {
+  count        = var.service_principal_enabled ? 1 : 0
+  display_name = local.names.service_principal
+  owners       = [data.azuread_client_config.current.object_id]
+
+  description = "Data Product Application - ${var.data_product_name}"
+  feature_tags {
+    custom_single_sign_on = false
+    enterprise            = false
+    gallery               = false
+    hide                  = false
+  }
+  identifier_uris  = ["http://${local.names.service_principal}"]
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "service_principal" {
+  count          = var.service_principal_enabled ? 1 : 0
+  application_id = one(azuread_application.application[*].id)
+  owners         = [data.azuread_client_config.current.object_id]
+
+  account_enabled              = true
+  app_role_assignment_required = false
+  description                  = "Data Product Service Principal - ${var.data_product_name}"
+  feature_tags {
+    custom_single_sign_on = false
+    enterprise            = false
+    gallery               = false
+    hide                  = false
+  }
+  notes = "Azure RBAC"
+}
+
+resource "time_rotating" "rotation" {
+  rotation_days = 90
+}
+
+resource "azuread_service_principal_password" "service_principal_password" {
+  count                = var.service_principal_enabled ? 1 : 0
+  service_principal_id = one(azuread_service_principal.service_principal[*].id)
+  display_name         = "Azure RBAC"
+  end_date_relative    = "2400h"
+  rotate_when_changed = {
+    rotation = time_rotating.rotation.id
+  }
+}
+
+resource "azuread_group_member" "security_group_sp_member" {
+  count            = var.service_principal_enabled && (data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  group_object_id  = one(data.azuread_group.security_group[*].object_id)
+  member_object_id = one(azuread_application.application[*].object_id)
+}

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -7,9 +7,15 @@ data "azuread_group" "security_group" {
 }
 
 resource "azuread_group_member" "security_group_uai_member" {
-  count            = var.user_assigned_identity_enabled && (data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count            = var.user_assigned_identity_enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
   member_object_id = one(azurerm_user_assigned_identity.user_assigned_identity[*].principal_id)
+}
+
+resource "azuread_group_member" "security_group_dbac_member" {
+  count            = one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  group_object_id  = one(data.azuread_group.security_group[*].object_id)
+  member_object_id = one(azurerm_databricks_access_connector.databricks_access_connector[*].identity[0].principal_id)
 }
 
 resource "azuread_application" "application" {
@@ -60,7 +66,7 @@ resource "azuread_service_principal_password" "service_principal_password" {
 }
 
 resource "azuread_group_member" "security_group_sp_member" {
-  count            = var.service_principal_enabled && (data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count            = var.service_principal_enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
   member_object_id = one(azuread_application.application[*].object_id)
 }

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -68,5 +68,5 @@ resource "azuread_service_principal_password" "service_principal_password" {
 resource "azuread_group_member" "security_group_sp_member" {
   count            = var.service_principal_enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
-  member_object_id = one(azuread_application.application[*].object_id)
+  member_object_id = one(azuread_application.application[*].application_id)
 }

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -68,5 +68,5 @@ resource "azuread_service_principal_password" "service_principal_password" {
 resource "azuread_group_member" "security_group_sp_member" {
   count            = var.service_principal_enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   group_object_id  = one(data.azuread_group.security_group[*].object_id)
-  member_object_id = one(azuread_application.application[*].application_id)
+  member_object_id = one(azuread_service_principal.service_principal[*].object_id)
 }

--- a/code/data-landing-zone/modules/dataproduct/azuread.tf
+++ b/code/data-landing-zone/modules/dataproduct/azuread.tf
@@ -30,7 +30,7 @@ resource "azuread_application" "application" {
     gallery               = false
     hide                  = false
   }
-  identifier_uris  = ["http://${local.names.service_principal}"]
+  identifier_uris  = []
   sign_in_audience = "AzureADMyOrg"
 }
 

--- a/code/data-landing-zone/modules/dataproduct/data.tf
+++ b/code/data-landing-zone/modules/dataproduct/data.tf
@@ -1,0 +1,1 @@
+data "azuread_client_config" "current" {}

--- a/code/data-landing-zone/modules/dataproduct/data.tf
+++ b/code/data-landing-zone/modules/dataproduct/data.tf
@@ -1,1 +1,0 @@
-data "azuread_client_config" "current" {}

--- a/code/data-landing-zone/modules/dataproduct/databricksaccessconnector.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksaccessconnector.tf
@@ -1,0 +1,9 @@
+resource "azurerm_databricks_access_connector" "databricks_access_connector" {
+  name                = local.names.databricks_access_connector
+  location            = var.location
+  resource_group_name = azurerm_resource_group.data_product_rg.name
+  tags                = var.tags
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/code/data-landing-zone/modules/dataproduct/databricksaccessconnector.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksaccessconnector.tf
@@ -1,4 +1,5 @@
 resource "azurerm_databricks_access_connector" "databricks_access_connector" {
+  count               = var.databricks_enabled && var.unity_catalog_configurations.enabled ? 1 : 0
   name                = local.names.databricks_access_connector
   location            = var.location
   resource_group_name = azurerm_resource_group.data_product_rg.name

--- a/code/data-landing-zone/modules/dataproduct/databricksunity-automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity-automation.tf
@@ -1,0 +1,46 @@
+resource "databricks_storage_credential" "storage_credential" {
+  count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.automation
+  metastore_id = var.unity_metastore_id
+  name         = local.names.databricks_storage_credential
+
+  azure_managed_identity {
+    access_connector_id = one(azurerm_databricks_access_connector.databricks_access_connector[*].id)
+  }
+  comment = "Managed identity credential for ${var.data_product_name} Data Product"
+}
+
+resource "databricks_external_location" "external_location" {
+  count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.automation
+  metastore_id = var.unity_metastore_id
+  name         = local.names.databricks_external_location
+
+  comment         = "Default Storage for ${var.data_product_name} Data Product"
+  credential_name = one(databricks_storage_credential.storage_credential[*].name)
+  skip_validation = false
+  url             = local.databricks_catalog_storage_root
+
+  depends_on = [
+    azuread_group_member.security_group_dbac_member
+  ]
+}
+
+resource "databricks_catalog" "catalog" {
+  count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.automation
+  metastore_id = var.unity_metastore_id
+  name         = local.names.databricks_catalog
+
+  comment       = "Data Product Catalog - ${var.data_product_name}"
+  force_destroy = false
+  properties = {
+    purpose = "Data Product Catalog - ${var.data_product_name}"
+  }
+  share_name   = var.unity_metastore_id
+  storage_root = local.databricks_catalog_storage_root
+
+  depends_on = [
+    databricks_external_location.external_location
+  ]
+}

--- a/code/data-landing-zone/modules/dataproduct/databricksunity-experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity-experimentation.tf
@@ -1,5 +1,6 @@
 resource "databricks_storage_credential" "storage_credential" {
-  count        = var.databricks_enabled && var.unity_catalog_configurations.enabled ? 1 : 0
+  count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
   name         = local.names.databricks_storage_credential
 
@@ -10,7 +11,8 @@ resource "databricks_storage_credential" "storage_credential" {
 }
 
 resource "databricks_external_location" "external_location" {
-  count        = var.databricks_enabled && var.unity_catalog_configurations.enabled ? 1 : 0
+  count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
   name         = local.names.databricks_external_location
 
@@ -25,7 +27,8 @@ resource "databricks_external_location" "external_location" {
 }
 
 resource "databricks_catalog" "catalog" {
-  count        = var.databricks_enabled && var.unity_catalog_configurations.enabled ? 1 : 0
+  count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
   name         = local.names.databricks_catalog
 

--- a/code/data-landing-zone/modules/dataproduct/databricksunity.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity.tf
@@ -1,7 +1,7 @@
 resource "databricks_storage_credential" "storage_credential" {
   metastore_id = var.unity_metastore_id
-  name = local.names.databricks_storage_credential
-  
+  name         = local.names.databricks_storage_credential
+
   azure_managed_identity {
     access_connector_id = azurerm_databricks_access_connector.databricks_access_connector.id
   }
@@ -10,12 +10,12 @@ resource "databricks_storage_credential" "storage_credential" {
 
 resource "databricks_external_location" "external_location" {
   metastore_id = var.unity_metastore_id
-  name = local.names.databricks_external_location
-  
-  comment = "Default Storage for ${var.data_product_name} Data Product"
+  name         = local.names.databricks_external_location
+
+  comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = databricks_storage_credential.storage_credential.name
   skip_validation = false
-  url = local.databricks_catalog_storage_root
+  url             = local.databricks_catalog_storage_root
 }
 
 resource "databricks_catalog" "catalog" {

--- a/code/data-landing-zone/modules/dataproduct/databricksunity.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity.tf
@@ -1,0 +1,36 @@
+resource "databricks_storage_credential" "storage_credential" {
+  metastore_id = var.unity_metastore_id
+  name = local.names.databricks_storage_credential
+  
+  azure_managed_identity {
+    access_connector_id = azurerm_databricks_access_connector.databricks_access_connector.id
+  }
+  comment = "Managed identity credential for ${var.data_product_name} Data Product"
+}
+
+resource "databricks_external_location" "external_location" {
+  metastore_id = var.unity_metastore_id
+  name = local.names.databricks_external_location
+  
+  comment = "Default Storage for ${var.data_product_name} Data Product"
+  credential_name = databricks_storage_credential.storage_credential.name
+  skip_validation = false
+  url = local.databricks_catalog_storage_root
+}
+
+resource "databricks_catalog" "catalog" {
+  metastore_id = var.unity_metastore_id
+  name         = local.names.databricks_catalog
+
+  comment       = "Data Product Catalog - ${var.data_product_name}"
+  force_destroy = false
+  properties = {
+    purpose = "Data Product Catalog - ${var.data_product_name}"
+  }
+  share_name   = var.unity_metastore_id
+  storage_root = local.databricks_catalog_storage_root
+
+  depends_on = [
+    databricks_external_location.external_location
+  ]
+}

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -16,7 +16,7 @@ resource "databricks_external_location" "automation_external_location" {
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.automation_storage_credential[*].name)
-  skip_validation = false
+  skip_validation = true
   url             = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -1,7 +1,6 @@
 resource "databricks_storage_credential" "automation_storage_credential" {
   count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.automation
-  metastore_id = var.unity_metastore_id
   name         = local.names.databricks_storage_credential
 
   azure_managed_identity {

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -10,9 +10,9 @@ resource "databricks_storage_credential" "automation_storage_credential" {
 }
 
 resource "databricks_external_location" "automation_external_location" {
-  count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
-  provider     = databricks.automation
-  name         = local.names.databricks_external_location
+  count    = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider = databricks.automation
+  name     = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.automation_storage_credential[*].name)

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -1,4 +1,4 @@
-resource "databricks_storage_credential" "storage_credential" {
+resource "databricks_storage_credential" "automation_storage_credential" {
   count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.automation
   metastore_id = var.unity_metastore_id
@@ -10,14 +10,14 @@ resource "databricks_storage_credential" "storage_credential" {
   comment = "Managed identity credential for ${var.data_product_name} Data Product"
 }
 
-resource "databricks_external_location" "external_location" {
+resource "databricks_external_location" "automation_external_location" {
   count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.automation
   metastore_id = var.unity_metastore_id
   name         = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
-  credential_name = one(databricks_storage_credential.storage_credential[*].name)
+  credential_name = one(databricks_storage_credential.automation_storage_credential[*].name)
   skip_validation = false
   url             = local.databricks_catalog_storage_root
 
@@ -26,7 +26,7 @@ resource "databricks_external_location" "external_location" {
   ]
 }
 
-resource "databricks_catalog" "catalog" {
+resource "databricks_catalog" "automation_catalog" {
   count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.automation
   metastore_id = var.unity_metastore_id
@@ -41,6 +41,6 @@ resource "databricks_catalog" "catalog" {
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [
-    databricks_external_location.external_location
+    databricks_external_location.automation_external_location
   ]
 }

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -22,6 +22,10 @@ resource "databricks_external_location" "automation_external_location" {
   depends_on = [
     azuread_group_member.security_group_dbac_member
   ]
+  timeouts {
+    create = "5m"
+    update = "5m"
+  }
 }
 
 resource "databricks_catalog" "automation_catalog" {

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -12,7 +12,6 @@ resource "databricks_storage_credential" "automation_storage_credential" {
 resource "databricks_external_location" "automation_external_location" {
   count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.automation
-  metastore_id = var.unity_metastore_id
   name         = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -16,7 +16,7 @@ resource "databricks_external_location" "automation_external_location" {
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.automation_storage_credential[*].name)
-  skip_validation = true
+  skip_validation = false
   url             = local.databricks_catalog_storage_root
 
   depends_on = [
@@ -35,8 +35,6 @@ resource "databricks_catalog" "automation_catalog" {
   properties = {
     purpose = "Data Product Catalog - ${var.data_product_name}"
   }
-  # provider_name = 
-  # share_name   = var.unity_metastore_id
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -35,7 +35,8 @@ resource "databricks_catalog" "automation_catalog" {
   properties = {
     purpose = "Data Product Catalog - ${var.data_product_name}"
   }
-  share_name   = var.unity_metastore_id
+  # provider_name = 
+  # share_name   = var.unity_metastore_id
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -1,7 +1,7 @@
 resource "databricks_storage_credential" "automation_storage_credential" {
-  count        = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
-  provider     = databricks.automation
-  name         = local.names.databricks_storage_credential
+  count    = var.databricks_enabled && !var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider = databricks.automation
+  name     = local.names.databricks_storage_credential
 
   azure_managed_identity {
     access_connector_id = one(azurerm_databricks_access_connector.databricks_access_connector[*].id)

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_automation.tf
@@ -22,10 +22,6 @@ resource "databricks_external_location" "automation_external_location" {
   depends_on = [
     azuread_group_member.security_group_dbac_member
   ]
-  timeouts {
-    create = "5m"
-    update = "5m"
-  }
 }
 
 resource "databricks_catalog" "automation_catalog" {

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -10,9 +10,9 @@ resource "databricks_storage_credential" "experimentation_storage_credential" {
 }
 
 resource "databricks_external_location" "experimentation_external_location" {
-  count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
-  provider     = databricks.experimentation
-  name         = local.names.databricks_external_location
+  count    = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider = databricks.experimentation
+  name     = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.experimentation_storage_credential[*].name)

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -1,4 +1,4 @@
-resource "databricks_storage_credential" "storage_credential" {
+resource "databricks_storage_credential" "experimentation_storage_credential" {
   count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
@@ -10,14 +10,14 @@ resource "databricks_storage_credential" "storage_credential" {
   comment = "Managed identity credential for ${var.data_product_name} Data Product"
 }
 
-resource "databricks_external_location" "external_location" {
+resource "databricks_external_location" "experimentation_external_location" {
   count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
   name         = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
-  credential_name = one(databricks_storage_credential.storage_credential[*].name)
+  credential_name = one(databricks_storage_credential.experimentation_storage_credential[*].name)
   skip_validation = false
   url             = local.databricks_catalog_storage_root
 
@@ -26,7 +26,7 @@ resource "databricks_external_location" "external_location" {
   ]
 }
 
-resource "databricks_catalog" "catalog" {
+resource "databricks_catalog" "experimentation_catalog" {
   count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.experimentation
   metastore_id = var.unity_metastore_id
@@ -41,6 +41,6 @@ resource "databricks_catalog" "catalog" {
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [
-    databricks_external_location.external_location
+    databricks_external_location.experimentation_external_location
   ]
 }

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -12,7 +12,6 @@ resource "databricks_storage_credential" "experimentation_storage_credential" {
 resource "databricks_external_location" "experimentation_external_location" {
   count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.experimentation
-  metastore_id = var.unity_metastore_id
   name         = local.names.databricks_external_location
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -16,7 +16,7 @@ resource "databricks_external_location" "experimentation_external_location" {
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.experimentation_storage_credential[*].name)
-  skip_validation = false
+  skip_validation = true
   url             = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -16,7 +16,7 @@ resource "databricks_external_location" "experimentation_external_location" {
 
   comment         = "Default Storage for ${var.data_product_name} Data Product"
   credential_name = one(databricks_storage_credential.experimentation_storage_credential[*].name)
-  skip_validation = true
+  skip_validation = false
   url             = local.databricks_catalog_storage_root
 
   depends_on = [
@@ -35,8 +35,6 @@ resource "databricks_catalog" "experimentation_catalog" {
   properties = {
     purpose = "Data Product Catalog - ${var.data_product_name}"
   }
-  # provider_name = 
-  # share_name   = var.unity_metastore_id
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -1,7 +1,7 @@
 resource "databricks_storage_credential" "experimentation_storage_credential" {
-  count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
-  provider     = databricks.experimentation
-  name         = local.names.databricks_storage_credential
+  count    = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
+  provider = databricks.experimentation
+  name     = local.names.databricks_storage_credential
 
   azure_managed_identity {
     access_connector_id = one(azurerm_databricks_access_connector.databricks_access_connector[*].id)

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -1,7 +1,6 @@
 resource "databricks_storage_credential" "experimentation_storage_credential" {
   count        = var.databricks_enabled && var.databricks_experimentation && var.unity_catalog_configurations.enabled ? 1 : 0
   provider     = databricks.experimentation
-  metastore_id = var.unity_metastore_id
   name         = local.names.databricks_storage_credential
 
   azure_managed_identity {

--- a/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
+++ b/code/data-landing-zone/modules/dataproduct/databricksunity_experimentation.tf
@@ -35,7 +35,8 @@ resource "databricks_catalog" "experimentation_catalog" {
   properties = {
     purpose = "Data Product Catalog - ${var.data_product_name}"
   }
-  share_name   = var.unity_metastore_id
+  # provider_name = 
+  # share_name   = var.unity_metastore_id
   storage_root = local.databricks_catalog_storage_root
 
   depends_on = [

--- a/code/data-landing-zone/modules/dataproduct/grants.tf
+++ b/code/data-landing-zone/modules/dataproduct/grants.tf
@@ -1,22 +1,22 @@
-data "databricks_group" "security_group" {
-  count        = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.unity_catalog_configurations.group_name != "" ? 1 : 0
-  display_name = var.unity_catalog_configurations.group_name
-}
+# data "databricks_group" "security_group" {
+#   count        = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.unity_catalog_configurations.group_name != "" ? 1 : 0
+#   display_name = var.unity_catalog_configurations.group_name
+# }
 
 resource "databricks_grants" "grants_experimentation_catalog" {
-  count   = var.databricks_experimentation && one(data.databricks_group.security_group[*].id) != null ? 1 : 0
+  count   = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.databricks_experimentation && var.unity_catalog_configurations.group_name != "" ? 1 : 0
   catalog = one(databricks_catalog.experimentation_catalog[*].name)
   grant {
-    principal  = one(data.databricks_group.security_group[*].id)
+    principal  = var.unity_catalog_configurations.group_name
     privileges = ["ALL_PRIVILEGES"]
   }
 }
 
 resource "databricks_grants" "grants_automation_catalog" {
-  count   = !var.databricks_experimentation && one(data.databricks_group.security_group[*].id) != null ? 1 : 0
+  count   = var.databricks_enabled && var.unity_catalog_configurations.enabled && !var.databricks_experimentation && var.unity_catalog_configurations.group_name != "" ? 1 : 0
   catalog = one(databricks_catalog.automation_catalog[*].name)
   grant {
-    principal  = one(data.databricks_group.security_group[*].id)
+    principal  = var.unity_catalog_configurations.group_name
     privileges = ["ALL_PRIVILEGES"]
   }
 }

--- a/code/data-landing-zone/modules/dataproduct/grants.tf
+++ b/code/data-landing-zone/modules/dataproduct/grants.tf
@@ -1,0 +1,22 @@
+data "databricks_group" "security_group" {
+  count        = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.unity_catalog_configurations.group_name != "" ? 1 : 0
+  display_name = var.unity_catalog_configurations.group_name
+}
+
+resource "databricks_grants" "grants_experimentation_catalog" {
+  count   = var.databricks_experimentation && one(data.databricks_group.security_group[*].id) != null ? 1 : 0
+  catalog = one(databricks_catalog.experimentation_catalog[*].name)
+  grant {
+    principal  = one(data.databricks_group.security_group[*].id)
+    privileges = ["ALL_PRIVILEGES"]
+  }
+}
+
+resource "databricks_grants" "grants_automation_catalog" {
+  count   = !var.databricks_experimentation && one(data.databricks_group.security_group[*].id) != null ? 1 : 0
+  catalog = one(databricks_catalog.automation_catalog[*].name)
+  grant {
+    principal  = one(data.databricks_group.security_group[*].id)
+    privileges = ["ALL_PRIVILEGES"]
+  }
+}

--- a/code/data-landing-zone/modules/dataproduct/grants.tf
+++ b/code/data-landing-zone/modules/dataproduct/grants.tf
@@ -1,8 +1,3 @@
-# data "databricks_group" "security_group" {
-#   count        = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.unity_catalog_configurations.group_name != "" ? 1 : 0
-#   display_name = var.unity_catalog_configurations.group_name
-# }
-
 resource "databricks_grants" "grants_experimentation_catalog" {
   count   = var.databricks_enabled && var.unity_catalog_configurations.enabled && var.databricks_experimentation && var.unity_catalog_configurations.group_name != "" ? 1 : 0
   catalog = one(databricks_catalog.experimentation_catalog[*].name)

--- a/code/data-landing-zone/modules/dataproduct/keyvault.tf
+++ b/code/data-landing-zone/modules/dataproduct/keyvault.tf
@@ -1,3 +1,5 @@
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_key_vault" "key_vault" {
   name                = local.names.key_vault
   location            = var.location

--- a/code/data-landing-zone/modules/dataproduct/keyvault.tf
+++ b/code/data-landing-zone/modules/dataproduct/keyvault.tf
@@ -1,0 +1,151 @@
+resource "azurerm_key_vault" "key_vault" {
+  name                = local.names.key_vault
+  location            = var.location
+  resource_group_name = azurerm_resource_group.data_product_rg.name
+  tags                = var.tags
+
+  access_policy                   = []
+  enable_rbac_authorization       = true
+  enabled_for_deployment          = false
+  enabled_for_disk_encryption     = false
+  enabled_for_template_deployment = false
+  network_acls {
+    bypass                     = "AzureServices"
+    default_action             = "Deny"
+    ip_rules                   = []
+    virtual_network_subnet_ids = []
+  }
+  public_network_access_enabled = true
+  purge_protection_enabled      = true
+  sku_name                      = "standard"
+  soft_delete_retention_days    = 7
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+}
+
+resource "azapi_resource" "key_vault_secret_service_principal_tenant_id" {
+  count     = var.service_principal_enabled ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "servicePrincipalTenantId"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(azuread_service_principal.service_principal[*].application_tenant_id)
+    }
+  })
+}
+
+resource "azapi_resource" "key_vault_secret_service_principal_object_id" {
+  count     = var.service_principal_enabled ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "servicePrincipalObjectId"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(azuread_application.application[*].object_id)
+    }
+  })
+}
+
+resource "azapi_resource" "key_vault_secret_service_principal_client_id" {
+  count     = var.service_principal_enabled ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "servicePrincipalClientId"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(azuread_service_principal.service_principal[*].application_id)
+    }
+  })
+}
+
+resource "azapi_resource" "key_vault_secret_service_principal_client_secret" {
+  count     = var.service_principal_enabled ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "servicePrincipalClientSecret"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(azuread_service_principal_password.service_principal_password[*].value)
+    }
+  })
+}
+
+resource "azapi_resource" "key_vault_secret_security_group_display_name" {
+  count     = one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "securityGroupDisplayName"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(data.azuread_group.security_group[*].display_name)
+    }
+  })
+}
+
+resource "azapi_resource" "key_vault_secret_security_group_object_id" {
+  count     = one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  type      = "Microsoft.KeyVault/vaults/secrets@2023-02-01"
+  name      = "securityGroupObjectId"
+  parent_id = azurerm_key_vault.key_vault.id
+
+  body = jsonencode({
+    properties = {
+      attributes = {
+        enabled = true
+      }
+      contentType = "text/plain"
+      value       = one(data.azuread_group.security_group[*].object_id)
+    }
+  })
+}
+
+resource "azurerm_private_endpoint" "key_vault_private_endpoint" {
+  count               = var.network_enabled ? 1 : 0
+  name                = "${azurerm_key_vault.key_vault.name}-pe"
+  location            = var.location
+  resource_group_name = azurerm_key_vault.key_vault.resource_group_name
+  tags                = var.tags
+
+  custom_network_interface_name = "${azurerm_key_vault.key_vault.name}-nic"
+  private_service_connection {
+    name                           = "${azurerm_key_vault.key_vault.name}-pe"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_key_vault.key_vault.id
+    subresource_names              = ["vault"]
+  }
+  subnet_id = var.private_endpoints_subnet_id
+  dynamic "private_dns_zone_group" {
+    for_each = var.private_dns_zone_id_key_vault == "" ? [] : [1]
+    content {
+      name = "${azurerm_key_vault.key_vault.name}-arecord"
+      private_dns_zone_ids = [
+        var.private_dns_zone_id_key_vault
+      ]
+    }
+  }
+}

--- a/code/data-landing-zone/modules/dataproduct/keyvault.tf
+++ b/code/data-landing-zone/modules/dataproduct/keyvault.tf
@@ -140,7 +140,7 @@ resource "azurerm_private_endpoint" "key_vault_private_endpoint" {
     private_connection_resource_id = azurerm_key_vault.key_vault.id
     subresource_names              = ["vault"]
   }
-  subnet_id = azapi_resource.subnet.id
+  subnet_id = one(azapi_resource.subnet[*].id)
   dynamic "private_dns_zone_group" {
     for_each = var.private_dns_zone_id_key_vault == "" ? [] : [1]
     content {

--- a/code/data-landing-zone/modules/dataproduct/keyvault.tf
+++ b/code/data-landing-zone/modules/dataproduct/keyvault.tf
@@ -140,7 +140,7 @@ resource "azurerm_private_endpoint" "key_vault_private_endpoint" {
     private_connection_resource_id = azurerm_key_vault.key_vault.id
     subresource_names              = ["vault"]
   }
-  subnet_id = var.private_endpoints_subnet_id
+  subnet_id = azapi_resource.subnet.id
   dynamic "private_dns_zone_group" {
     for_each = var.private_dns_zone_id_key_vault == "" ? [] : [1]
     content {

--- a/code/data-landing-zone/modules/dataproduct/keyvault.tf
+++ b/code/data-landing-zone/modules/dataproduct/keyvault.tf
@@ -17,7 +17,7 @@ resource "azurerm_key_vault" "key_vault" {
     ip_rules                   = []
     virtual_network_subnet_ids = []
   }
-  public_network_access_enabled = true
+  public_network_access_enabled = false
   purge_protection_enabled      = true
   sku_name                      = "standard"
   soft_delete_retention_days    = 7

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -7,6 +7,7 @@ locals {
     container_enriched     = var.data_product_name
     container_curated      = var.data_product_name
     container_workspace    = var.data_product_name
+    service_principal      = var.data_product_name
   }
 
   virtual_network = {

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -1,14 +1,19 @@
 locals {
   names = {
-    resource_group         = "${var.data_product_name}-rg"
-    subnet                 = "DataProductSubnet-${var.data_product_name}"
-    user_assigned_identity = "${var.data_product_name}-uai001"
-    key_vault              = "${var.data_product_name}-vault001"
-    container_raw          = var.data_product_name
-    container_enriched     = var.data_product_name
-    container_curated      = var.data_product_name
-    container_workspace    = var.data_product_name
-    service_principal      = var.data_product_name
+    resource_group              = "${var.data_product_name}-rg"
+    subnet                      = "DataProductSubnet-${var.data_product_name}"
+    user_assigned_identity      = "${var.data_product_name}-uai001"
+    key_vault                   = "${var.data_product_name}-vault001"
+    container_raw               = var.data_product_name
+    container_enriched          = var.data_product_name
+    container_curated           = var.data_product_name
+    container_workspace         = var.data_product_name
+    service_principal           = var.data_product_name
+    databricks_access_connector = "${var.data_product_name}-dbac001"
+    databricks_cluster          = "${var.data_product_name}-cluster001"
+    databricks_storage_credential = var.data_product_name
+    databricks_external_location = var.data_product_name
+    databricks_catalog          = var.data_product_name
   }
 
   virtual_network = {
@@ -45,4 +50,7 @@ locals {
     resource_group_name = try(split("/", var.datalake_workspace_id)[4], "")
     name                = try(split("/", var.datalake_workspace_id)[8], "")
   }
+
+  databricks_catalog_storage_root_container = ""
+  databricks_catalog_storage_root = "abfss://${data.azurerm_storage_account.datalake_workspace.name}@${local.databricks_catalog_storage_root_container}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -63,5 +63,5 @@ locals {
     curated   = one(azapi_resource.container_curated[*].name)
     workspace = one(azapi_resource.container_workspace[*].name)
   }
-  databricks_catalog_storage_root = "abfss://${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net/"
+  databricks_catalog_storage_root = "abfss://${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -63,5 +63,5 @@ locals {
     curated   = one(azapi_resource.container_curated[*].name)
     workspace = one(azapi_resource.container_workspace[*].name)
   }
-  databricks_catalog_storage_root = "abfss://${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net/"
+  databricks_catalog_storage_root = "abfss://${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -58,10 +58,10 @@ locals {
     workspace = data.azurerm_storage_account.datalake_workspace.name
   }
   container_names = {
-    raw       = azapi_resource.container_raw.name
-    enriched  = azapi_resource.container_enriched.name
-    curated   = azapi_resource.container_curated.name
-    workspace = azapi_resource.container_workspace.name
+    raw       = one(azapi_resource.container_raw[*].name)
+    enriched  = one(azapi_resource.container_enriched[*].name)
+    curated   = one(azapi_resource.container_curated[*].name)
+    workspace = one(azapi_resource.container_workspace[*].name)
   }
   databricks_catalog_storage_root = "abfss://${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -1,19 +1,19 @@
 locals {
   names = {
-    resource_group              = "${var.data_product_name}-rg"
-    subnet                      = "DataProductSubnet-${var.data_product_name}"
-    user_assigned_identity      = "${var.data_product_name}-uai001"
-    key_vault                   = "${var.data_product_name}-vault001"
-    container_raw               = var.data_product_name
-    container_enriched          = var.data_product_name
-    container_curated           = var.data_product_name
-    container_workspace         = var.data_product_name
-    service_principal           = var.data_product_name
-    databricks_access_connector = "${var.data_product_name}-dbac001"
-    databricks_cluster          = "${var.data_product_name}-cluster001"
+    resource_group                = "${var.data_product_name}-rg"
+    subnet                        = "DataProductSubnet-${var.data_product_name}"
+    user_assigned_identity        = "${var.data_product_name}-uai001"
+    key_vault                     = "${var.data_product_name}-vault001"
+    container_raw                 = var.data_product_name
+    container_enriched            = var.data_product_name
+    container_curated             = var.data_product_name
+    container_workspace           = var.data_product_name
+    service_principal             = var.data_product_name
+    databricks_access_connector   = "${var.data_product_name}-dbac001"
+    databricks_cluster            = "${var.data_product_name}-cluster001"
     databricks_storage_credential = var.data_product_name
-    databricks_external_location = var.data_product_name
-    databricks_catalog          = var.data_product_name
+    databricks_external_location  = var.data_product_name
+    databricks_catalog            = var.data_product_name
   }
 
   virtual_network = {
@@ -52,5 +52,5 @@ locals {
   }
 
   databricks_catalog_storage_root_container = ""
-  databricks_catalog_storage_root = "abfss://${data.azurerm_storage_account.datalake_workspace.name}@${local.databricks_catalog_storage_root_container}.dfs.core.windows.net/"
+  databricks_catalog_storage_root           = "abfss://${data.azurerm_storage_account.datalake_workspace.name}@${local.databricks_catalog_storage_root_container}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -51,6 +51,6 @@ locals {
     name                = try(split("/", var.datalake_workspace_id)[8], "")
   }
 
-  databricks_catalog_storage_root_container = ""
+  databricks_catalog_storage_root_container = var.unity_catalog_configurations.storage_root == "raw" ? one(azapi_resource.container_raw[*].name) : var.unity_catalog_configurations.storage_root == "enriched" ? one(azapi_resource.container_enriched[*].name) : var.unity_catalog_configurations.storage_root == "curated" ? one(azapi_resource.container_curated[*].name) : var.unity_catalog_configurations.storage_root == "workspace" ? one(azapi_resource.container_workspace[*].name) : ""
   databricks_catalog_storage_root           = "abfss://${data.azurerm_storage_account.datalake_workspace.name}@${local.databricks_catalog_storage_root_container}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -3,6 +3,7 @@ locals {
     resource_group         = "${var.data_product_name}-rg"
     subnet                 = "DataProductSubnet-${var.data_product_name}"
     user_assigned_identity = "${var.data_product_name}-uai001"
+    key_vault              = "${var.data_product_name}-vault001"
     container_raw          = var.data_product_name
     container_enriched     = var.data_product_name
     container_curated      = var.data_product_name

--- a/code/data-landing-zone/modules/dataproduct/locals.tf
+++ b/code/data-landing-zone/modules/dataproduct/locals.tf
@@ -51,6 +51,17 @@ locals {
     name                = try(split("/", var.datalake_workspace_id)[8], "")
   }
 
-  databricks_catalog_storage_root_container = var.unity_catalog_configurations.storage_root == "raw" ? one(azapi_resource.container_raw[*].name) : var.unity_catalog_configurations.storage_root == "enriched" ? one(azapi_resource.container_enriched[*].name) : var.unity_catalog_configurations.storage_root == "curated" ? one(azapi_resource.container_curated[*].name) : var.unity_catalog_configurations.storage_root == "workspace" ? one(azapi_resource.container_workspace[*].name) : ""
-  databricks_catalog_storage_root           = "abfss://${data.azurerm_storage_account.datalake_workspace.name}@${local.databricks_catalog_storage_root_container}.dfs.core.windows.net/"
+  datalake_names = {
+    raw       = data.azurerm_storage_account.datalake_raw.name
+    enriched  = data.azurerm_storage_account.datalake_enriched.name
+    curated   = data.azurerm_storage_account.datalake_curated.name
+    workspace = data.azurerm_storage_account.datalake_workspace.name
+  }
+  container_names = {
+    raw       = azapi_resource.container_raw.name
+    enriched  = azapi_resource.container_enriched.name
+    curated   = azapi_resource.container_curated.name
+    workspace = azapi_resource.container_workspace.name
+  }
+  databricks_catalog_storage_root = "abfss://${lookup(local.datalake_names, var.unity_catalog_configurations.storage_root, "")}@${lookup(local.container_names, var.unity_catalog_configurations.storage_root, "")}.dfs.core.windows.net/"
 }

--- a/code/data-landing-zone/modules/dataproduct/roleassignments.tf
+++ b/code/data-landing-zone/modules/dataproduct/roleassignments.tf
@@ -6,35 +6,35 @@ resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_resour
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_subnet" {
-  count                = one(azapi_resource.subnet[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.network_enabled && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.subnet[*].id)
   role_definition_name = "Network Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_raw" {
-  count                = one(azapi_resource.container_raw[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.raw != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_raw[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_enriched" {
-  count                = one(azapi_resource.container_enriched[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.enriched != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_enriched[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_curated" {
-  count                = one(azapi_resource.container_curated[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.curated != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_curated[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_workspace" {
-  count                = one(azapi_resource.container_workspace[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.workspace != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_workspace[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)

--- a/code/data-landing-zone/modules/dataproduct/roleassignments.tf
+++ b/code/data-landing-zone/modules/dataproduct/roleassignments.tf
@@ -12,10 +12,24 @@ resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_subnet
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
+resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_storage_raw" {
+  count                = var.containers_enabled.raw && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  scope                = data.azurerm_storage_account.datalake_raw.id
+  role_definition_name = "Storage Blob Delegator"
+  principal_id         = one(data.azuread_group.security_group[*].object_id)
+}
+
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_raw" {
   count                = var.containers_enabled.raw && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_raw[*].id)
   role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = one(data.azuread_group.security_group[*].object_id)
+}
+
+resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_storage_enriched" {
+  count                = var.containers_enabled.enriched && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  scope                = data.azurerm_storage_account.datalake_enriched.id
+  role_definition_name = "Storage Blob Delegator"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
@@ -26,10 +40,24 @@ resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_contai
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
+resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_storage_curated" {
+  count                = var.containers_enabled.curated && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  scope                = data.azurerm_storage_account.datalake_curated.id
+  role_definition_name = "Storage Blob Delegator"
+  principal_id         = one(data.azuread_group.security_group[*].object_id)
+}
+
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_curated" {
   count                = var.containers_enabled.curated && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_curated[*].id)
   role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = one(data.azuread_group.security_group[*].object_id)
+}
+
+resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_storage_workspace" {
+  count                = var.containers_enabled.workspace && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  scope                = data.azurerm_storage_account.datalake_workspace.id
+  role_definition_name = "Storage Blob Delegator"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 

--- a/code/data-landing-zone/modules/dataproduct/roleassignments.tf
+++ b/code/data-landing-zone/modules/dataproduct/roleassignments.tf
@@ -20,21 +20,21 @@ resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_contai
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_enriched" {
-  count                = one(azapi_resource.container_enriched[*].id) && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = one(azapi_resource.container_enriched[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_enriched[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_curated" {
-  count                = one(azapi_resource.container_curated[*].id) && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = one(azapi_resource.container_curated[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_curated[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_workspace" {
-  count                = one(azapi_resource.container_workspace[*].id) && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = one(azapi_resource.container_workspace[*].id) != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_workspace[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)

--- a/code/data-landing-zone/modules/dataproduct/roleassignments.tf
+++ b/code/data-landing-zone/modules/dataproduct/roleassignments.tf
@@ -13,28 +13,28 @@ resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_subnet
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_raw" {
-  count                = var.containers_enabled.raw != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.raw && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_raw[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_enriched" {
-  count                = var.containers_enabled.enriched != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.enriched && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_enriched[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_curated" {
-  count                = var.containers_enabled.curated != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.curated && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_curated[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)
 }
 
 resource "azurerm_role_assignment" "user_assigned_identity_roleassignment_container_workspace" {
-  count                = var.containers_enabled.workspace != null && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
+  count                = var.containers_enabled.workspace && one(data.azuread_group.security_group[*].object_id) != null ? 1 : 0
   scope                = one(azapi_resource.container_workspace[*].id)
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = one(data.azuread_group.security_group[*].object_id)

--- a/code/data-landing-zone/modules/dataproduct/storagecontainers.tf
+++ b/code/data-landing-zone/modules/dataproduct/storagecontainers.tf
@@ -1,5 +1,4 @@
 data "azurerm_storage_account" "datalake_raw" {
-  count               = var.containers_enabled.raw ? 1 : 0
   name                = local.datalake_raw.name
   resource_group_name = local.datalake_raw.resource_group_name
 }
@@ -8,7 +7,7 @@ resource "azapi_resource" "container_raw" {
   count     = var.containers_enabled.raw ? 1 : 0
   type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01"
   name      = local.names.container_raw
-  parent_id = "${one(data.azurerm_storage_account.datalake_raw[*].id)}/blobServices/default"
+  parent_id = "${data.azurerm_storage_account.datalake_raw.id}/blobServices/default"
 
   body = jsonencode({
     properties = {

--- a/code/data-landing-zone/modules/dataproduct/storagecontainers.tf
+++ b/code/data-landing-zone/modules/dataproduct/storagecontainers.tf
@@ -1,4 +1,5 @@
 data "azurerm_storage_account" "datalake_raw" {
+  count               = var.containers_enabled.raw ? 1 : 0
   name                = local.datalake_raw.name
   resource_group_name = local.datalake_raw.resource_group_name
 }
@@ -7,7 +8,7 @@ resource "azapi_resource" "container_raw" {
   count     = var.containers_enabled.raw ? 1 : 0
   type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01"
   name      = local.names.container_raw
-  parent_id = "${data.azurerm_storage_account.datalake_raw.id}/blobServices/default"
+  parent_id = "${one(data.azurerm_storage_account.datalake_raw[*].id)}/blobServices/default"
 
   body = jsonencode({
     properties = {

--- a/code/data-landing-zone/modules/dataproduct/variables.tf
+++ b/code/data-landing-zone/modules/dataproduct/variables.tf
@@ -206,13 +206,24 @@ variable "unity_metastore_id" {
 }
 
 variable "databricks_enabled" {
-  description = "Specifies whether identity resources should be deployed for the data product."
+  description = "Specifies whether databricks resources should be deployed for the data product."
   type        = bool
   sensitive   = false
   default     = false
   validation {
     condition     = var.databricks_enabled == true || var.databricks_enabled == false
     error_message = "Please specify a valid value for 'databricks.enabled'. 'databricks.enabled' needs to be a boolean."
+  }
+}
+
+variable "databricks_experimentation" {
+  description = "Specifies whether databricks resources should be deployed in the automation or experimentation workspace."
+  type        = bool
+  sensitive   = false
+  default     = true
+  validation {
+    condition     = var.databricks_experimentation == true || var.databricks_experimentation == false
+    error_message = "Please specify a valid value for 'databricks.experimentation'. 'databricks.experimentation' needs to be a boolean."
   }
 }
 

--- a/code/data-landing-zone/modules/dataproduct/variables.tf
+++ b/code/data-landing-zone/modules/dataproduct/variables.tf
@@ -76,6 +76,16 @@ variable "subnet_cidr_range" {
   }
 }
 
+variable "private_dns_zone_id_key_vault" {
+  description = "Specifies the resource ID of the private DNS zone for Azure Key Vault endpoints."
+  type        = string
+  sensitive   = false
+  validation {
+    condition     = var.private_dns_zone_id_key_vault == "" || (length(split("/", var.private_dns_zone_id_key_vault)) == 9 && endswith(var.private_dns_zone_id_key_vault, "privatelink.vaultcore.azure.net"))
+    error_message = "Please specify a valid resource ID for the private DNS Zone."
+  }
+}
+
 variable "identity_enabled" {
   description = "Specifies whether identity resources should be deployed for the data product."
   type        = bool

--- a/code/data-landing-zone/modules/dataproduct/variables.tf
+++ b/code/data-landing-zone/modules/dataproduct/variables.tf
@@ -146,7 +146,7 @@ variable "containers_enabled" {
       var.containers_enabled.curated == true || var.containers_enabled.curated == false,
       var.containers_enabled.workspace == true || var.containers_enabled.workspace == false,
     ])
-    error_message = "Please specify a valid value for 'network.enabled'. 'network.enabled' needs to be a boolean."
+    error_message = "Please specify a valid value for 'storage_container._'. 'storage_container.raw', 'storage_container.enriched', 'storage_container.curated', 'storage_container.workspace' needs to be a boolean."
   }
 }
 
@@ -202,5 +202,34 @@ variable "unity_metastore_id" {
   validation {
     condition     = var.unity_metastore_id == "" || length(var.unity_metastore_id) >= 2
     error_message = "Please specify a valid name."
+  }
+}
+
+variable "databricks_enabled" {
+  description = "Specifies whether identity resources should be deployed for the data product."
+  type        = bool
+  sensitive   = false
+  default     = false
+  validation {
+    condition     = var.databricks_enabled == true || var.databricks_enabled == false
+    error_message = "Please specify a valid value for 'databricks.enabled'. 'databricks.enabled' needs to be a boolean."
+  }
+}
+
+variable "unity_catalog_configurations" {
+  description = "Specifies the configurations for unity catalog."
+  type = object({
+    enabled      = optional(bool, false)
+    group_name   = optional(string, "")
+    storage_root = optional(string, "")
+  })
+  sensitive = false
+  validation {
+    condition = alltrue([
+      var.unity_catalog_configurations.enabled == true || var.unity_catalog_configurations.enabled == false,
+      var.unity_catalog_configurations.group_name == "" || length(var.unity_catalog_configurations.group_name) >= 2,
+      var.unity_catalog_configurations.storage_root == "" || var.unity_catalog_configurations.storage_root == "raw" || var.unity_catalog_configurations.storage_root == "enriched" || var.unity_catalog_configurations.storage_root == "curated" || var.unity_catalog_configurations.storage_root == "workspace",
+    ])
+    error_message = "Please specify a valid value for 'databricks.unity_catalog._'."
   }
 }

--- a/code/data-landing-zone/modules/dataproduct/variables.tf
+++ b/code/data-landing-zone/modules/dataproduct/variables.tf
@@ -193,3 +193,14 @@ variable "datalake_workspace_id" {
     error_message = "Please specify a valid resource ID."
   }
 }
+
+variable "unity_metastore_id" {
+  description = "Specifies the id of the Databricks Unity metastore."
+  type        = string
+  sensitive   = false
+  default     = ""
+  validation {
+    condition     = var.unity_metastore_id == "" || length(var.unity_metastore_id) >= 2
+    error_message = "Please specify a valid name."
+  }
+}

--- a/code/data-landing-zone/modules/dataproduct/versions.tf
+++ b/code/data-landing-zone/modules/dataproduct/versions.tf
@@ -7,6 +7,10 @@ terraform {
     databricks = {
       source  = "databricks/databricks"
       version = "1.14.3"
+      configuration_aliases = [
+        databricks.automation,
+        databricks.experimentation,
+      ]
     }
   }
 }

--- a/code/data-landing-zone/modules/dataproduct/versions.tf
+++ b/code/data-landing-zone/modules/dataproduct/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "azure/azapi"
       version = "1.5.0"
     }
+    databricks = {
+      source  = "databricks/databricks"
+      version = "1.14.2"
+    }
   }
 }

--- a/code/data-landing-zone/modules/dataproduct/versions.tf
+++ b/code/data-landing-zone/modules/dataproduct/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     databricks = {
       source  = "databricks/databricks"
-      version = "1.14.2"
+      version = "1.14.3"
     }
   }
 }

--- a/code/data-landing-zone/variables.tf
+++ b/code/data-landing-zone/variables.tf
@@ -115,6 +115,12 @@ variable "data_product_library_path" {
   default     = ""
 }
 
+variable "data_product_template_file_variables" {
+  type        = any
+  description = "If specified, provides the ability to define custom template variables used when reading in dtaa product template files from the library path."
+  default     = {}
+}
+
 variable "private_dns_zone_id_blob" {
   description = "Specifies the resource ID of the private DNS zone for Azure Storage blob endpoints."
   type        = string

--- a/code/data-landing-zone/vars.dev.tfvars
+++ b/code/data-landing-zone/vars.dev.tfvars
@@ -11,6 +11,7 @@ unity_metastore_name                    = "perfectthymetech-northeurope"
 unity_metastore_id                      = "9884193e-1edc-4ddd-8e9c-ce570e9cc57a"
 data_platform_subscription_ids          = []
 data_product_library_path               = "./dataproducts"
+data_product_template_file_variables    = {}
 private_dns_zone_id_blob                = "/subscriptions/8f171ff9-2b5b-4f0f-aed5-7fa360a1d094/resourceGroups/mycrp-prd-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
 private_dns_zone_id_dfs                 = "/subscriptions/8f171ff9-2b5b-4f0f-aed5-7fa360a1d094/resourceGroups/mycrp-prd-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.dfs.core.windows.net"
 private_dns_zone_id_queue               = "/subscriptions/8f171ff9-2b5b-4f0f-aed5-7fa360a1d094/resourceGroups/mycrp-prd-global-dns/providers/Microsoft.Network/privateDnsZones/privatelink.queue.core.windows.net"

--- a/code/data-management-zone/keyvault.tf
+++ b/code/data-management-zone/keyvault.tf
@@ -15,7 +15,7 @@ resource "azurerm_key_vault" "key_vault" {
     ip_rules                   = []
     virtual_network_subnet_ids = []
   }
-  public_network_access_enabled = true
+  public_network_access_enabled = false
   purge_protection_enabled      = true
   sku_name                      = "standard"
   soft_delete_retention_days    = 7


### PR DESCRIPTION
**Proposed changes**:
- Add Data Product definition template
- Update data lake module structure by adding data file
- Add azapi dependency to data product module
- Add network configuration for data product
- Add resource group deployment for data product
- Add storage container deployment for data product
- Add user assigned identity for data product
- Add necessary role assignments for data products
- Add locals and variables for data product deployment
- [x] Add configuration to core module with generating map for data products (based on definition and environments) with templatefile and fileset
- [x] Conditional subnet deployment
- [x] Add Service Principal creation and deployment
- [x] Add identity config with security groups and role assignments
- [x] Add Key Vault with Secret deployment of SP etc.
- [x] Add templatefile properties as vars
- [x] Add Databricks deployment to Data Product with Unity, Cluster, Security Group and access
- [x] Convert local to var reference for data_product_library_path

Links:
- https://developer.hashicorp.com/terraform/language/functions/templatefile
- https://developer.hashicorp.com/terraform/language/functions/fileset
